### PR TITLE
Post body remover workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ CONVERTS TO >>>>>
     <wp:author_login><![CDATA[Master Shifu]]></wp:author_login>
 </wp:author>
 ```
-`static final String TAGS_SELECTOR = "a[rel=category tag]";` - Grabs the tags of the post  
+`static final String TAGS_SELECTOR = "a[rel=category tag]";` - Grabs the tags of the post. NOTE: you can set `POST_BODY_SELECTOR_REMOVER` to an element to be removed from the post body, if there is no posy body wrapper or some element needs to be removed   
 ```
 <a href="link" rel="category tag">Wuxi Finger Hold</a>
 >>>>>

--- a/src/main/java/hubXmlBuilders.java
+++ b/src/main/java/hubXmlBuilders.java
@@ -186,6 +186,9 @@ class hubXmlBuilders {
 
             // Build <content:encoded>
             Elements postBody = doc.select(hubXmlSelectors.POST_BODY_SELECTOR);
+            if (hubXmlSelectors.POST_BODY_SELECTOR_REMOVER.length() != 0) {
+                postBody.select(hubXmlSelectors.POST_BODY_SELECTOR_REMOVER).remove();
+            }
             if (!postBody.isEmpty()) {
                 Element contentEncoded = new Element("encoded", CONTENT_ENCODED);
                 CDATA contentEncodedCdata = new CDATA(postBody.get(0).toString());

--- a/src/main/java/hubXmlSelectors.java
+++ b/src/main/java/hubXmlSelectors.java
@@ -4,13 +4,15 @@ class hubXmlSelectors {
     // VARIABLES TO SET
     // :)
     // Required Elements for a given <item> ff an element is not found in a given post, a default value is set, and the error is logged
-     static final String[] POSTS = {"https://www.kungfupanda.com/dragon-warrior", "https://www.kungfupanda.com/valley-of-peace", "https://www.kungfupanda.com/jade-palace"};
+    static final String[] POSTS = {"https://www.kungfupanda.com/dragon-warrior", "https://www.kungfupanda.com/valley-of-peace", "https://www.kungfupanda.com/jade-palace"};
     static final String TITLE_SELECTOR = "title";
     static final String DATE_SELECTOR = ".published";
     static final String META_DESCRIPTION_SELECTOR = "meta[name=description]";
     static final String AUTHOR_SELECTOR = "a[rel=author]";
     static final String TAGS_SELECTOR = "a[rel=category tag]";
     static final String POST_BODY_SELECTOR = ".post-body";
+    // Optional Element to remove from the post body content (good to use when there is not a post body wrapper)
+    static final String POST_BODY_SELECTOR_REMOVER = ".post-social-sharing-icons";
 
     // Optional elements for a given <item> no default value or error is logged
 


### PR DESCRIPTION
Adds a new `POST_BODY_SELECTOR_REMOVER` to allow a element to be removed from the post body, if there is no post body selector, or if some element needs to be removed (like social icons or something)