### PR TITLE
Figure out featured image type

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ CONVERTS TO >>>>>
 <content:encoded><![CDATA[<div class=".post-body">You must find <strong>inner peace</strong> to be an affective dragon warrior... and eat lost of dumplings</div>]]</content:encoded>
 ```
 _Optional Elements:_  
-`static final String FEATURED_IMAGE_SELECTOR = ".featured-image";` - Grabs the featured image of the post (NOTE: the image url must be in the html of the page as a `src` attribute of an `<img>` tag. It is also possible to grab inline `background` CSS declarations, but requires some modifications to the `String featuredImageUri` in `hubXml/src/main/java/hubXmlBuilders.java`,  a commented out example is in there)
+`static final String FEATURED_IMAGE_SELECTOR = ".featured-image";` - Grabs the featured image of the post. Will work for `src` attribute of image element, `content` attribute of meta element (like `meta[property="og:image"]`) or inline css `background`/`background-image` declarations  
 ```
 <img class="featured-image" src="https://www.kungfupanda.com/dumplings/featured-image.jpg">
 CONVERTS TO >>>>>

--- a/src/main/java/hubXmlBuilders.java
+++ b/src/main/java/hubXmlBuilders.java
@@ -102,6 +102,25 @@ class hubXmlBuilders {
 
     }
 
+    private static String metaOrSrcOrInlineFeaturedImage(Elements featuredImage) {
+
+        if (hubXmlSelectors.FEATURED_IMAGE_SELECTOR.contains("meta")) {
+
+            return featuredImage.get(0).attr("content");
+
+        } else if (featuredImage.get(0).attr("src").length() > 0){
+
+            return featuredImage.get(0).attr("src");
+
+        } else {
+
+            String featuredImageStyle = featuredImage.attr("style");
+            return featuredImageStyle.split("//")[1].split("'\\)|\\)|\"\\)")[0];
+
+        }
+
+    }
+
     static void buildItem(String post, Integer id) {
 
         try {
@@ -196,12 +215,7 @@ class hubXmlBuilders {
             Elements featuredImage = doc.select(hubXmlSelectors.FEATURED_IMAGE_SELECTOR);
             if (!featuredImage.isEmpty()) {
 
-                // IF IMAGE SRC IS SRC ELEMENT OF IMG
-                String featuredImageUri = featuredImage.get(0).attr("src");
-
-                // IF IMAGE SRC IS CONTENT ATTRIBUTE OF META TAG make SELECTOR "meta[property=og:image]"
-                // String featuredImageUri = featuredImage.get(0).attr("content");
-
+                String featuredImageUri = metaOrSrcOrInlineFeaturedImage(featuredImage);
                 // IF IMAGE SRC IS IN INLINE CSS OF ELEMENT, USE BELOW INSTEAD. MAKE SURE TO CHECK indexOfs VALUES FOR SECURE/NOT-SECURE AND CSS DECLARATION DELIMITERS
                 // PROTOCOL OF IMAGE SRC | indexOf("https://") or indexOf("http://")
                 // BACKGROUND URL SYNTAX | indexOf("')") OR indexOf(")") OR indexOf("\")")

--- a/src/main/java/hubXmlBuilders.java
+++ b/src/main/java/hubXmlBuilders.java
@@ -216,12 +216,6 @@ class hubXmlBuilders {
             if (!featuredImage.isEmpty()) {
 
                 String featuredImageUri = metaOrSrcOrInlineFeaturedImage(featuredImage);
-                // IF IMAGE SRC IS IN INLINE CSS OF ELEMENT, USE BELOW INSTEAD. MAKE SURE TO CHECK indexOfs VALUES FOR SECURE/NOT-SECURE AND CSS DECLARATION DELIMITERS
-                // PROTOCOL OF IMAGE SRC | indexOf("https://") or indexOf("http://")
-                // BACKGROUND URL SYNTAX | indexOf("')") OR indexOf(")") OR indexOf("\")")
-                // String featuredImageStyle = featuredImage.attr("style");
-                // String featuredImageUri =  featuredImageStyle.substring(featuredImageStyle.indexOf("https://"), featuredImageStyle.indexOf("\")"));
-
                 Element postMeta = new Element ("post_meta", WP);
                 item.addContent(postMeta);
                 postMeta.addContent(new Element ("meta_key", WP).setText("_thumbnail_id"));


### PR DESCRIPTION
This logic figures out of the Featured Image URL is the `src` attribute of an `img` tag, `content` attribute of a meta tag, or inline CSS `background`/background-image` declaration