### PR TITLE
handle inline FI better

### DIFF
--- a/src/main/java/hubXmlBuilders.java
+++ b/src/main/java/hubXmlBuilders.java
@@ -117,7 +117,7 @@ class hubXmlBuilders {
         } else {
 
             String featuredImageStyle = featuredImage.attr("style");
-            return featuredImageStyle.split("//")[1].split("'\\)|\\)|\"\\)")[0];
+            return "http://" + featuredImageStyle.split("//")[1].split("'\\)|\\)|\"\\)")[0];
 
         }
 


### PR DESCRIPTION
Whoops, this returned an FI with no protocol which confused the logic in `buildFeaturedImage` 